### PR TITLE
Add device-orientation cube and neon line demos

### DIFF
--- a/dev-claude-lines3d.html
+++ b/dev-claude-lines3d.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claude Lines 3D</title>
+  <style>
+    body,html{margin:0;padding:0;overflow:hidden;background:#000;}
+    #canvas{display:block;width:100vw;height:100vh;}
+    #permissionBtn{position:absolute;top:20px;left:20px;padding:10px 20px;font-family:sans-serif;font-size:16px;}
+  </style>
+</head>
+<body>
+  <canvas id="canvas"></canvas>
+  <button id="permissionBtn" style="display:none;">Enable Motion</button>
+  <script>
+    const canvas=document.getElementById('canvas');
+    const ctx=canvas.getContext('2d');
+    let deviceOrientation={alpha:0,beta:0,gamma:0};
+    let orientationBuffer=[];
+    function resize(){canvas.width=window.innerWidth;canvas.height=window.innerHeight;}
+    window.addEventListener('resize',resize);resize();
+    function handleOrientation(e){
+      const raw={alpha:e.alpha||0,beta:e.beta||0,gamma:e.gamma||0};
+      orientationBuffer.push(raw);
+      if(orientationBuffer.length>5)orientationBuffer.shift();
+      let totalW=0,smoothed={alpha:0,beta:0,gamma:0};
+      for(let i=0;i<orientationBuffer.length;i++){
+        const w=(i+1)/orientationBuffer.length;totalW+=w;
+        smoothed.alpha+=orientationBuffer[i].alpha*w;
+        smoothed.beta+=orientationBuffer[i].beta*w;
+        smoothed.gamma+=orientationBuffer[i].gamma*w;
+      }
+      smoothed.alpha/=totalW;smoothed.beta/=totalW;smoothed.gamma/=totalW;
+      deviceOrientation=smoothed;
+    }
+    function project3D(x,y,z){
+      const r=Math.PI/180;
+      const roll=deviceOrientation.gamma*r;
+      const pitch=deviceOrientation.beta*r;
+      const yaw=deviceOrientation.alpha*r;
+      const cosR=Math.cos(roll),sinR=Math.sin(roll);
+      const cosP=Math.cos(pitch),sinP=Math.sin(pitch);
+      const cosY=Math.cos(yaw),sinY=Math.sin(yaw);
+      let tx=x*cosY - z*sinY; let ty=y; let tz=x*sinY + z*cosY;
+      x=tx; y=ty*cosP - tz*sinP; z=ty*sinP + tz*cosP;
+      tx=x*cosR - y*sinR; ty=x*sinR + y*cosR; tz=z;
+      const vd=800; const distance=Math.max(1,vd+tz); const scale=vd/distance;
+      return {x:tx*scale,y:ty*scale,z:tz};
+    }
+    function draw(){
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      const centerX=canvas.width/2, centerY=canvas.height/2;
+      ctx.save();
+      ctx.translate(centerX,centerY);
+      const gridSize=40, gridExtent=25, height=gridSize*10;
+      ctx.strokeStyle='#ff00ff';
+      ctx.lineWidth=1;
+      for(let x=-gridExtent;x<=gridExtent;x+=2){
+        for(let z=-gridExtent;z<=gridExtent;z+=2){
+          const b=project3D(x*gridSize,0,z*gridSize);
+          const t=project3D(x*gridSize,-height,z*gridSize);
+          const avgZ=(b.z+t.z)/2; const alpha=Math.max(0.1,Math.min(0.6,1-Math.abs(avgZ)/1200));
+          if(alpha>0.15){
+            ctx.globalAlpha=alpha;
+            ctx.beginPath();
+            ctx.moveTo(b.x,b.y); ctx.lineTo(t.x,t.y); ctx.stroke();
+          }
+        }
+      }
+      ctx.restore();
+      requestAnimationFrame(draw);
+    }
+    function requestPermission(){
+      if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){
+        DeviceOrientationEvent.requestPermission().then(state=>{if(state==='granted'){window.addEventListener('deviceorientation',handleOrientation);document.getElementById('permissionBtn').style.display='none';}}).catch(console.error);
+      }
+    }
+    window.addEventListener('load',()=>{
+      draw();
+      const btn=document.getElementById('permissionBtn');
+      if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){
+        btn.style.display='block';
+        btn.addEventListener('click',requestPermission);
+      }else{
+        window.addEventListener('deviceorientation',handleOrientation);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/dev-gemini-cube3d.html
+++ b/dev-gemini-cube3d.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gemini Cube 3D</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <style>
+    body,html{margin:0;padding:0;overflow:hidden;background:#000;}
+    #cubeCanvas{display:block;width:100vw;height:100vh;}
+    #permissionBtn{position:absolute;top:20px;left:20px;padding:10px 20px;font-family:sans-serif;font-size:16px;}
+  </style>
+</head>
+<body>
+  <canvas id="cubeCanvas"></canvas>
+  <button id="permissionBtn" style="display:none;">Enable Motion</button>
+  <script>
+    let scene,camera,renderer,wallGrids;
+    function initScene(){
+      scene=new THREE.Scene();
+      scene.background=new THREE.Color(0x000000);
+      camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,0.1,1000);
+      camera.position.set(0,1.5,5);
+      renderer=new THREE.WebGLRenderer({canvas:document.getElementById('cubeCanvas'),antialias:true});
+      renderer.setSize(window.innerWidth,window.innerHeight);
+      renderer.setPixelRatio(window.devicePixelRatio);
+      scene.add(new THREE.AmbientLight(0x404040));
+      const light=new THREE.PointLight(0x00ffff,1,100);
+      light.position.set(0,5,0);
+      scene.add(light);
+      const floorSize=50;const floorDiv=50;
+      const floorMat=new THREE.LineBasicMaterial({color:0x00ffff,opacity:0.4,transparent:true});
+      const floorGrid=new THREE.GridHelper(floorSize,floorDiv,0x00ffff,0x008888);floorGrid.material=floorMat;scene.add(floorGrid);
+      wallGrids=new THREE.Group();
+      const wallSize=50;const wallDiv=50;const wallMat=new THREE.LineBasicMaterial({color:0x00ffff,opacity:0.2,transparent:true});
+      const front=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);front.rotation.x=Math.PI/2;front.position.z=-wallSize/2;front.position.y=wallSize/2;front.material=wallMat.clone();wallGrids.add(front);
+      const back=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);back.rotation.x=Math.PI/2;back.position.z=wallSize/2;back.position.y=wallSize/2;back.material=wallMat.clone();wallGrids.add(back);
+      const left=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);left.rotation.z=Math.PI/2;left.position.x=-wallSize/2;left.position.y=wallSize/2;left.material=wallMat.clone();wallGrids.add(left);
+      const right=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);right.rotation.z=Math.PI/2;right.position.x=wallSize/2;right.position.y=wallSize/2;right.material=wallMat.clone();wallGrids.add(right);
+      const ceiling=new THREE.GridHelper(floorSize,floorDiv,0x00ffff,0x008888);ceiling.position.y=wallSize;ceiling.material=floorMat.clone();ceiling.material.opacity=0.2;wallGrids.add(ceiling);
+      scene.add(wallGrids);
+      window.addEventListener('resize',onResize);
+    }
+    function onResize(){camera.aspect=window.innerWidth/window.innerHeight;camera.updateProjectionMatrix();renderer.setSize(window.innerWidth,window.innerHeight);}
+    function handleOrientation(e){const r=Math.PI/180;const alpha=e.alpha?e.alpha*r:0;const beta=e.beta?e.beta*r:0;const gamma=e.gamma?e.gamma*r:0;const euler=new THREE.Euler();euler.set(beta,gamma,-alpha,'YXZ');camera.quaternion.setFromEuler(euler);}
+    function requestPermission(){if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){DeviceOrientationEvent.requestPermission().then(state=>{if(state==='granted'){window.addEventListener('deviceorientation',handleOrientation);document.getElementById('permissionBtn').style.display='none';}}).catch(console.error);}}
+    function animate(){requestAnimationFrame(animate);renderer.render(scene,camera);}
+    window.addEventListener('load',()=>{initScene();animate();const btn=document.getElementById('permissionBtn');if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){btn.style.display='block';btn.addEventListener('click',requestPermission);}else{window.addEventListener('deviceorientation',handleOrientation);}});
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `dev-gemini-cube3d.html` with 3D grid cube using Three.js
- add `dev-claude-lines3d.html` rendering neon pink vertical lines responsive to device orientation

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6878eafad19c832aa1b7173a27ebed94