### PR TITLE
Add retro GUI overlay

### DIFF
--- a/claude.html
+++ b/claude.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TRON CyberFit - Train Like an Android</title>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="retro-gui.css">
     <style>
         * {
             margin: 0;
@@ -782,5 +784,6 @@
         // Start animation
         animate();
     </script>
+    <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/deepseek.html
+++ b/deepseek.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>TRON NeoGrid Fitness - Precision Training</title>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="retro-gui.css">
     <style>
         * {
             margin: 0;
@@ -615,5 +617,6 @@
         // Start the app when loaded
         window.addEventListener('load', initApp);
     </script>
+    <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/demos-torus.html
+++ b/demos-torus.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rotating Torus Demo</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="retro-gui.css">
   <style>
     body {
       margin: 0;
@@ -80,5 +82,6 @@
 
     draw();
   </script>
+  <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/dev-claude-lines3d.html
+++ b/dev-claude-lines3d.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TRON Claude Lines 3D</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="retro-gui.css">
   <style>
     body,html{margin:0;padding:0;overflow:hidden;background:#000;}
     #canvas{display:block;width:100vw;height:100vh;}
@@ -87,5 +89,6 @@
       }
     });
   </script>
+  <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/dev-gemini-cube3d.html
+++ b/dev-gemini-cube3d.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TRON Gemini Cube 3D</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="retro-gui.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <style>
     body,html{margin:0;padding:0;overflow:hidden;background:#000;}
@@ -47,5 +49,6 @@
     function animate(){requestAnimationFrame(animate);renderer.render(scene,camera);}
     window.addEventListener('load',()=>{initScene();animate();const btn=document.getElementById('permissionBtn');if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){btn.style.display='block';btn.addEventListener('click',requestPermission);}else{window.addEventListener('deviceorientation',handleOrientation);}});
   </script>
+  <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/dev-new.html
+++ b/dev-new.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TRON Combined 3D Demo</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="retro-gui.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <style>
     body,html{margin:0;padding:0;overflow:hidden;background:#000;}
@@ -164,5 +166,6 @@
       }
     });
   </script>
+  <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/gemini.html
+++ b/gemini.html
@@ -8,6 +8,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <!-- Google Fonts - Orbitron for sci-fi look -->
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="retro-gui.css">
     <style>
         /* Basic reset and body styling */
         body {
@@ -549,5 +551,6 @@
             showModal('Welcome, Trainee!', 'Prepare for intensive low-impact, high-repetition training. Hold your phone firmly. The 3D grid will align with the real-world horizon. Perform quick, precise "flick" or "punch-like" movements with your phone to register **Steps**. Ensure your device orientation sensors are enabled.');
         };
     </script>
+    <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GROS 64 Clone</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="retro-gui.css">
   <style>
     body {
       background:#4030A1;
@@ -81,5 +82,6 @@
 
     init();
   </script>
+  <script src="retro-gui.js"></script>
 </body>
 </html>

--- a/retro-gui.css
+++ b/retro-gui.css
@@ -1,0 +1,55 @@
+#retro-gui-toggle {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  padding: 4px 8px;
+  background: #24188f;
+  color: #fff;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  border: 2px solid #fff;
+  cursor: pointer;
+  z-index: 10000;
+}
+
+#retro-gui-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 260px;
+  height: 100%;
+  background: #4030A1;
+  color: #fff;
+  font-family: 'Press Start 2P', monospace;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  padding: 20px;
+  box-sizing: border-box;
+  z-index: 9999;
+  overflow-y: auto;
+}
+
+#retro-gui-panel.open {
+  transform: translateX(0);
+}
+
+#retro-gui-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#retro-gui-panel li {
+  margin: 8px 0;
+}
+
+#retro-gui-panel a {
+  color: #fff;
+  text-decoration: none;
+}
+
+#retro-gui-panel a:hover {
+  background: #24188f;
+  display: block;
+  padding-left: 4px;
+}

--- a/retro-gui.js
+++ b/retro-gui.js
@@ -1,0 +1,36 @@
+(function(){
+  function initRetroGUI(){
+    const toggle=document.createElement('div');
+    toggle.id='retro-gui-toggle';
+    toggle.textContent='MENU';
+    const panel=document.createElement('div');
+    panel.id='retro-gui-panel';
+    const list=document.createElement('ul');
+    panel.appendChild(list);
+    document.body.appendChild(panel);
+    document.body.appendChild(toggle);
+    toggle.addEventListener('click',()=>{panel.classList.toggle('open');});
+    fetch('demos.json')
+      .then(r=>r.json())
+      .then(d=>{
+        d.files.forEach(file=>{
+          const li=document.createElement('li');
+          const a=document.createElement('a');
+          a.href=file;
+          a.textContent=file;
+          li.appendChild(a);
+          list.appendChild(li);
+        });
+      })
+      .catch(()=>{
+        const li=document.createElement('li');
+        li.textContent='No demos found';
+        list.appendChild(li);
+      });
+  }
+  if(document.readyState==='loading'){
+    document.addEventListener('DOMContentLoaded',initRetroGUI);
+  }else{
+    initRetroGUI();
+  }
+})();


### PR DESCRIPTION
## Summary
- add `retro-gui.js` for a sliding menu overlay
- style overlay with `retro-gui.css`
- include new retro GUI on all HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879649fd1c4832abf7e22759692681e