### PR TITLE
Fix label overlay visibility

### DIFF
--- a/dev-gemini-cube3d.html
+++ b/dev-gemini-cube3d.html
@@ -16,7 +16,7 @@
 </head>
 <body>
   <canvas id="cubeCanvas"></canvas>
-  <div id="labels" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;"></div>
+  <div id="labels" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:500;"></div>
   <div id="stats" style="position:absolute;top:10px;right:10px;color:#0f0;font-family:monospace;font-size:14px;z-index:1000;background:rgba(0,0,0,0.5);padding:4px;"></div>
   <button id="permissionBtn" style="position:absolute;top:20px;left:20px;padding:10px 20px;font-family:sans-serif;font-size:16px;display:none;">Enable Motion</button>
   <script>
@@ -32,6 +32,8 @@
     }
 
     function updateLabels(){
+      // Ensure the camera matrices reflect any changes before projecting
+      camera.updateMatrixWorld();
       const width=window.innerWidth;
       const height=window.innerHeight;
       labelData.forEach(o=>{


### PR DESCRIPTION
## Summary
- ensure camera matrices update before projecting label locations
- keep label overlay above WebGL canvas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a1485f7f0832a9ab45c0c0ec50e4c