### PR TITLE
Add ball explosion waves

### DIFF
--- a/dev-new.html
+++ b/dev-new.html
@@ -23,8 +23,10 @@
   <script>
     let scene,camera,renderer,wallGrids,verticalLines;
     const labelData=[];
-    const drops=[];
-    const DROP_COUNT=10;
+    let drop;
+    let dropCount=0;
+    const MAX_DROPS=30;
+    const rings=[];
     let orientationOffsetQuat=new THREE.Quaternion();
     let lastQuat=new THREE.Quaternion();
     let offsetInitialized=false;
@@ -67,7 +69,7 @@
       addPointWithLabel({x:0,y:1,z:0},'Origin');
       addPointWithLabel({x:5,y:1,z:5},'Alpha');
       addPointWithLabel({x:-5,y:1,z:-5},'Beta');
-      createDrops();
+      spawnDrop();
       updateLabels();
       window.addEventListener('resize',onResize);
     }
@@ -128,33 +130,59 @@
       labelData.push({pos:mesh.position,el:div});
     }
 
-    function resetDrop(mesh){
-      mesh.position.x=THREE.MathUtils.randFloatSpread(ROOM_SIZE);
-      mesh.position.z=THREE.MathUtils.randFloatSpread(ROOM_SIZE);
-      mesh.position.y=Math.random()*10+10;
-      mesh.material.color.setHex(0xffff00);
+    function spawnDrop(){
+      const geom=new THREE.SphereGeometry(0.3,16,16);
+      const mat=new THREE.MeshBasicMaterial({color:0xffff00});
+      drop=new THREE.Mesh(geom,mat);
+      drop.position.x=THREE.MathUtils.randFloatSpread(10);
+      drop.position.z=THREE.MathUtils.randFloatSpread(10);
+      drop.position.y=Math.random()*5+8;
+      scene.add(drop);
     }
 
-    function createDrops(){
-      const geom=new THREE.SphereGeometry(0.1,8,8);
-      for(let i=0;i<DROP_COUNT;i++){
-        const mat=new THREE.MeshBasicMaterial({color:0xffff00});
-        const mesh=new THREE.Mesh(geom,mat);
-        resetDrop(mesh);
-        scene.add(mesh);
-        drops.push(mesh);
+    function createExplosion(pos){
+      const count=5;
+      for(let i=0;i<count;i++){
+        const geo=new THREE.RingGeometry(0.2,0.25,32);
+        const mat=new THREE.MeshBasicMaterial({color:0xff8800,transparent:true,opacity:1});
+        const ring=new THREE.Mesh(geo,mat);
+        ring.rotation.x=-Math.PI/2;
+        ring.position.set(pos.x,0.05,pos.z);
+        ring.userData={delay:i*5};
+        rings.push(ring);
+        scene.add(ring);
       }
     }
 
-    function updateDrops(){
-      drops.forEach(d=>{
-        if(d.position.y>0.1){
-          d.position.y-=0.1;
-        }else{
-          d.position.y=0.1;
-          d.material.color.setHex(0xff8800);
+    function updateRings(){
+      for(let i=rings.length-1;i>=0;i--){
+        const r=rings[i];
+        if(r.userData.delay>0){r.userData.delay--;continue;}
+        r.scale.multiplyScalar(1.08);
+        r.material.opacity*=0.92;
+        if(r.material.opacity<0.02){
+          scene.remove(r);
+          r.geometry.dispose();
+          r.material.dispose();
+          rings.splice(i,1);
         }
-      });
+      }
+    }
+
+    function updateDrop(){
+      if(!drop)return;
+      if(drop.position.y>0.3){
+        drop.position.y-=0.2;
+      }else{
+        createExplosion(drop.position);
+        scene.remove(drop);
+        drop.geometry.dispose();
+        drop.material.dispose();
+        drop=null;
+        if(++dropCount<MAX_DROPS){
+          spawnDrop();
+        }
+      }
     }
 
     function updateLabels(){
@@ -219,7 +247,8 @@
 
     function animate(){
       requestAnimationFrame(animate);
-      updateDrops();
+      updateDrop();
+      updateRings();
       updateStats();
       updateLabels();
       renderer.render(scene,camera);


### PR DESCRIPTION
## Summary
- update `dev-new.html` to drop a single ball
- when ball hits ground create expanding rings that fade away
- spawn the next ball until 30 drops have occurred

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a2c1f6ab0832a8af9ea917abf4dd2