### PR TITLE
Add explosions and more balls

### DIFF
--- a/dev-new.html
+++ b/dev-new.html
@@ -24,9 +24,12 @@
     let scene,camera,renderer,wallGrids,verticalLines;
     const labelData=[];
     const drops=[];
-    const DROP_COUNT=10;
+    const explosions=[];
+    const DROP_COUNT=30;
     const GRAVITY=0.01;
     const BOUNCE_LOSS=0.6;
+    const EXPLOSION_PARTICLES=20;
+    const EXPLOSION_LIFETIME=60;
     let orientationOffsetQuat=new THREE.Quaternion();
     let lastQuat=new THREE.Quaternion();
     let offsetInitialized=false;
@@ -156,12 +159,46 @@
       }
     }
 
+    function createExplosion(position){
+      const group=new THREE.Group();
+      const geom=new THREE.SphereGeometry(0.05,4,4);
+      for(let i=0;i<EXPLOSION_PARTICLES;i++){
+        const mat=new THREE.MeshBasicMaterial({color:0xff6600});
+        const m=new THREE.Mesh(geom,mat);
+        m.position.copy(position);
+        m.userData.velocity=new THREE.Vector3(
+          THREE.MathUtils.randFloatSpread(0.5),
+          Math.random()*0.5,
+          THREE.MathUtils.randFloatSpread(0.5)
+        );
+        group.add(m);
+      }
+      scene.add(group);
+      explosions.push({group,life:0});
+    }
+
+    function updateExplosions(){
+      for(let i=explosions.length-1;i>=0;i--){
+        const e=explosions[i];
+        e.group.children.forEach(p=>{
+          p.position.add(p.userData.velocity);
+          p.userData.velocity.y-=GRAVITY*2;
+        });
+        e.life++;
+        if(e.life>EXPLOSION_LIFETIME){
+          scene.remove(e.group);
+          explosions.splice(i,1);
+        }
+      }
+    }
+
     function updateDrops(){
       drops.forEach(d=>{
         d.velocity-=GRAVITY;
         d.mesh.position.y+=d.velocity;
         if(d.mesh.position.y<=0.1){
           d.mesh.position.y=0.1;
+          createExplosion(d.mesh.position.clone());
           d.velocity=-d.velocity*BOUNCE_LOSS;
           if(Math.abs(d.velocity)<0.02){
             resetDrop(d);
@@ -230,13 +267,14 @@
       }
     }
 
-    function animate(){
-      requestAnimationFrame(animate);
-      updateDrops();
-      updateStats();
-      updateLabels();
-      renderer.render(scene,camera);
-    }
+      function animate(){
+        requestAnimationFrame(animate);
+        updateDrops();
+        updateExplosions();
+        updateStats();
+        updateLabels();
+        renderer.render(scene,camera);
+      }
 
     function updateStats(){
       const stats=document.getElementById('stats');


### PR DESCRIPTION
## Summary
- add explosion particle system for falling balls
- keep 30 balls active instead of 10

## Testing
- `node -e "require('fs').readFileSync('dev-new.html','utf8')"`

------
https://chatgpt.com/codex/tasks/task_e_687a2da0340c832aac549632399e0915