### PR TITLE
Adjust fall speed and explosion visuals

### DIFF
--- a/dev-new.html
+++ b/dev-new.html
@@ -26,7 +26,7 @@
     const drops=[];
     const explosions=[];
     const DROP_COUNT=30;
-    const GRAVITY=0.01;
+    const GRAVITY=0.004;
     const EXPLOSION_LIFETIME=60;
     let orientationOffsetQuat=new THREE.Quaternion();
     let lastQuat=new THREE.Quaternion();
@@ -158,13 +158,15 @@
     }
 
     function createExplosion(position){
-      const geom=new THREE.RingGeometry(0.1,0.12,32);
-      const mat=new THREE.MeshBasicMaterial({color:0xff6600,transparent:true,opacity:0.8,side:THREE.DoubleSide});
-      const ring=new THREE.Mesh(geom,mat);
-      ring.rotation.x=-Math.PI/2; // lay flat on the ground
-      ring.position.copy(position);
-      scene.add(ring);
-      explosions.push({mesh:ring,life:0});
+      for(let i=0;i<3;i++){
+        const geom=new THREE.RingGeometry(0.1+i*0.05,0.12+i*0.05,32);
+        const mat=new THREE.MeshBasicMaterial({color:0xff8800,transparent:true,opacity:0.8,side:THREE.DoubleSide});
+        const ring=new THREE.Mesh(geom,mat);
+        ring.rotation.x=-Math.PI/2; // lay flat on the ground
+        ring.position.copy(position);
+        scene.add(ring);
+        explosions.push({mesh:ring,life:0});
+      }
     }
 
     function updateExplosions(){


### PR DESCRIPTION
## Summary
- slow down the falling drops by reducing gravity
- brighten the explosion color and spawn multiple rings per explosion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a314f5674832aa0cd5beadfe283da