### PR TITLE
Add DEMOS text shadow, shading and version display

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,15 @@
       flex-direction: column;
       gap: 0.5rem;
     }
+    #version-display {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      color: #0ff;
+      font-size: 0.8rem;
+      font-family: inherit;
+      z-index: 1000;
+    }
   </style>
 </head>
 <body>
@@ -70,25 +79,59 @@
     <h1>TRON</h1>
     <div id="demo-list"></div>
   </div>
+  <div id="version-display"></div>
 
   <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/loaders/FontLoader.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/geometries/TextGeometry.js"></script>
   <script>
+    const VERSION = 'v011';
+    document.getElementById('version-display').textContent = VERSION;
+
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
     const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('bg'), antialias: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.shadowMap.enabled = true;
 
     camera.position.z = 5;
 
     const geometry = new THREE.TorusGeometry(1, 0.3, 16, 60);
-    const material = new THREE.MeshStandardMaterial({ color: 0x00ffff, wireframe: true });
+    const material = new THREE.MeshPhongMaterial({ color: 0x00ffff });
     const torus = new THREE.Mesh(geometry, material);
+    torus.castShadow = true;
+    torus.receiveShadow = true;
     scene.add(torus);
 
     const pointLight = new THREE.PointLight(0xffffff, 1);
     pointLight.position.set(5, 5, 5);
+    pointLight.castShadow = true;
     scene.add(pointLight);
     scene.add(new THREE.AmbientLight(0xffffff, 0.3));
+
+    const planeGeo = new THREE.PlaneGeometry(10, 10);
+    const planeMat = new THREE.ShadowMaterial({ opacity: 0.3 });
+    const plane = new THREE.Mesh(planeGeo, planeMat);
+    plane.rotation.x = -Math.PI / 2;
+    plane.position.y = -1.5;
+    plane.receiveShadow = true;
+    scene.add(plane);
+
+    const loader = new THREE.FontLoader();
+    loader.load('https://threejs.org/examples/fonts/helvetiker_regular.typeface.json', (font) => {
+      const textGeo = new THREE.TextGeometry('DEMOS', {
+        font,
+        size: 0.8,
+        height: 0.2,
+        curveSegments: 1,
+        bevelEnabled: false
+      });
+      const textMat = new THREE.MeshPhongMaterial({ color: 0x00ffff, shininess: 100 });
+      const textMesh = new THREE.Mesh(textGeo, textMat);
+      textMesh.position.set(-2, 0, 0);
+      textMesh.castShadow = true;
+      scene.add(textMesh);
+    });
 
     function addStar() {
       const geo = new THREE.SphereGeometry(0.02, 24, 24);


### PR DESCRIPTION
## Summary
- add a version display element
- use Phong shading and enable shadows for the torus
- load 3D DEMOS text with Phong material and shadows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884f35404b0832a948f74e4a3f3ddb3