### PR TITLE
docs: expand README with demo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # tron
-t.r.o.n.
+
+A collection of TRON-inspired 3D demos built with [Three.js](https://threejs.org/).
+
+## Demos
+
+The repository contains several self-contained HTML demo pages.
+Open `index.html` to view a menu. The list of available demos is stored in `demos.json`:
+
+- `demos-torus.html`
+- `gemini.html`
+- `gemini2.html`
+- `claude.html`
+- `deepseek.html`
+- `dev-gemini-cube3d.html`
+- `dev-claude-lines3d.html`
+- `dev-new.html`
+- `tron.html`
+
+Each page can be opened directly in a modern web browser.
+
+## Usage
+
+Serve the directory as static files or open `index.html` directly:
+
+```bash
+npx serve
+```
+
+Then navigate to the printed local address (usually <http://localhost:3000/>) to explore the demos.
+


### PR DESCRIPTION
## Summary
- document existing TRON-themed demo pages and how to launch them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bac29dd38832ab651f5fdeaa1fc59