### PR TITLE
chore: remove index page from demo list

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -1,7 +1,6 @@
 {
   "files": [
     "demos-torus.html",
-    "index.html",
     "gemini.html",
     "gemini2.html",
     "claude.html",

--- a/index.html
+++ b/index.html
@@ -164,7 +164,6 @@
       .then(data => {
         const list = document.getElementById('demo-list');
         data.files.forEach(f => {
-          if (f === 'index.html') return;
           const a = document.createElement('a');
           a.href = f;
           a.textContent = f;


### PR DESCRIPTION
## Summary
- drop `index.html` from `demos.json`
- simplify menu generation since index is no longer listed

## Testing
- `python -m json.tool demos.json`

------
https://chatgpt.com/codex/tasks/task_e_689bada81844832a9b2b9ab1d7600d94