### PR TITLE
fix index page rendering issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,9 @@
   <div id="version-display"></div>
 
   <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/build/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/loaders/FontLoader.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/geometries/TextGeometry.js"></script>
+  <!-- Use non-module versions so THREE.FontLoader and TextGeometry are available on the global THREE object -->
+  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/js/loaders/FontLoader.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/js/geometries/TextGeometry.js"></script>
   <script>
     const VERSION = 'v011';
     document.getElementById('version-display').textContent = VERSION;


### PR DESCRIPTION
## Summary
- load three.js FontLoader and TextGeometry from non-module scripts to restore 3D background and demo list on main page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa23086fb8832a90ab377a5e5cf3cc