### PR TITLE
Add JSON list of HTML demos and link rendering

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -1,14 +1,15 @@
 {
-  "version": "v0.24",
+  "version": "v0.25",
   "files": [
-    "demos-torus.html",
-    "gemini.html",
-    "gemini2.html",
-    "claude.html",
-    "deepseek.html",
     "dev-gemini-cube3d.html",
+    "claude.html",
+    "gemini2.html",
+    "tron.html",
+    "gemini.html",
+    "index.html",
     "dev-claude-lines3d.html",
-    "dev-new.html",
-    "tron.html"
+    "demos-torus.html",
+    "deepseek.html",
+    "dev-new.html"
   ]
 }

--- a/index.html
+++ b/index.html
@@ -162,15 +162,16 @@
     animate();
 
     const DEMO_FILES = [
-      'demos-torus.html',
-      'gemini.html',
-      'gemini2.html',
-      'claude.html',
-      'deepseek.html',
       'dev-gemini-cube3d.html',
+      'claude.html',
+      'gemini2.html',
+      'tron.html',
+      'gemini.html',
+      'index.html',
       'dev-claude-lines3d.html',
-      'dev-new.html',
-      'tron.html'
+      'demos-torus.html',
+      'deepseek.html',
+      'dev-new.html'
     ];
 
     function renderList(files) {


### PR DESCRIPTION
## Summary
- Include complete list of HTML demos in `demos.json` with version bump
- Sync `DEMO_FILES` fallback in `index.html` to display all pages as links

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa326efa18832a906735f83cb8a71c