### PR TITLE
Populate index from demos list and recolor torus

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.25",
+  "version": "v0.26",
   "files": [
     "dev-gemini-cube3d.html",
     "claude.html",

--- a/index.html
+++ b/index.html
@@ -77,23 +77,7 @@
   <canvas id="bg"></canvas>
   <div class="dashboard">
     <h1>TRON</h1>
-    <div id="demo-list">
-      <a href="README.md">README.md</a>
-      <a href="deepseek.html">deepseek.html</a>
-      <a href="dev-claude-lines3d.html">dev-claude-lines3d.html</a>
-      <a href="gemini.html">gemini.html</a>
-      <a href="retro-gui.css">retro-gui.css</a>
-      <a href="claude.html">claude.html</a>
-      <a href="demos-torus.html">demos-torus.html</a>
-      <a href="dev-gemini-cube3d.html">dev-gemini-cube3d.html</a>
-      <a href="gemini2.html">gemini2.html</a>
-      <a href="retro-gui.js">retro-gui.js</a>
-      <a href="console-overlay.js">console-overlay.js</a>
-      <a href="demos.json">demos.json</a>
-      <a href="dev-new.html">dev-new.html</a>
-      <a href="index.html">index.html</a>
-      <a href="tron.html">tron.html</a>
-    </div>
+    <div id="demo-list"></div>
   </div>
   <div id="version-display"></div>
 
@@ -102,9 +86,44 @@
   <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/js/loaders/FontLoader.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.153.0/examples/js/geometries/TextGeometry.js"></script>
   <script>
-    const DEFAULT_VERSION = 'v0.13';
+    const DEFAULT_VERSION = 'v0.26';
     const versionDisplay = document.getElementById('version-display');
+    const demoList = document.getElementById('demo-list');
     versionDisplay.textContent = DEFAULT_VERSION;
+    demoList.textContent = 'Loading demos…';
+
+    async function populateDemoList() {
+      try {
+        const response = await fetch('demos.json', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Failed to load demos.json: ${response.status}`);
+        }
+        const data = await response.json();
+        if (data.version) {
+          versionDisplay.textContent = data.version;
+        }
+        const files = Array.isArray(data.files) ? data.files : [];
+        const htmlFiles = files.filter((file) => /\.html?$/i.test(file)).sort((a, b) => a.localeCompare(b));
+
+        demoList.innerHTML = '';
+        if (!htmlFiles.length) {
+          demoList.textContent = 'No HTML demos found.';
+          return;
+        }
+
+        htmlFiles.forEach((file) => {
+          const link = document.createElement('a');
+          link.href = file;
+          link.textContent = file;
+          demoList.appendChild(link);
+        });
+      } catch (error) {
+        console.error(error);
+        demoList.textContent = 'Unable to load demo list.';
+      }
+    }
+
+    populateDemoList();
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
@@ -114,8 +133,24 @@
 
     camera.position.z = 5;
 
-    const geometry = new THREE.TorusGeometry(1, 0.3, 16, 60);
-    const material = new THREE.MeshPhongMaterial({ color: 0x00ffff });
+    const geometry = new THREE.TorusGeometry(1, 0.3, 32, 120);
+    const positionAttribute = geometry.attributes.position;
+    const colors = new Float32Array(positionAttribute.count * 3);
+    const color = new THREE.Color();
+    for (let i = 0; i < positionAttribute.count; i++) {
+      const x = positionAttribute.getX(i);
+      const y = positionAttribute.getY(i);
+      const z = positionAttribute.getZ(i);
+      const angle = Math.atan2(y, x);
+      const normalizedAngle = (angle + Math.PI) / (Math.PI * 2);
+      const lightness = 0.45 + 0.25 * Math.sin((z + 0.3) * 3);
+      color.setHSL(normalizedAngle, 0.85, lightness);
+      colors[i * 3] = color.r;
+      colors[i * 3 + 1] = color.g;
+      colors[i * 3 + 2] = color.b;
+    }
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    const material = new THREE.MeshPhongMaterial({ vertexColors: true, shininess: 200, specular: 0xffffff });
     const torus = new THREE.Mesh(geometry, material);
     torus.castShadow = true;
     torus.receiveShadow = true;


### PR DESCRIPTION
## Summary
- load the index menu from demos.json so it always reflects the HTML files in the project
- show a friendly loading/error message and surface the version from the JSON manifest when available
- upgrade the torus geometry to use vibrant vertex colours for a neon gradient effect and bump the manifest version

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d275083a18832a907372782b18b7f3