### PR TITLE
Add shaded low and high poly toruses to demo

### DIFF
--- a/torus.html
+++ b/torus.html
@@ -73,6 +73,8 @@
 
     camera.position.z = 5;
 
+    const toruses = [];
+
     const geometry = new THREE.TorusGeometry(1, 0.3, 32, 120);
     const positionAttribute = geometry.attributes.position;
     const colors = new Float32Array(positionAttribute.count * 3);
@@ -96,7 +98,27 @@
     const torus = new THREE.Mesh(geometry, material);
     torus.castShadow = true;
     torus.receiveShadow = true;
+    torus.position.x = -1.4;
+    toruses.push(torus);
     scene.add(torus);
+
+    const lowPolyGeo = new THREE.TorusGeometry(0.85, 0.28, 8, 16);
+    const lowPolyMat = new THREE.MeshStandardMaterial({ color: 0x00ffaa, metalness: 0.15, roughness: 0.85, flatShading: true });
+    const lowPolyTorus = new THREE.Mesh(lowPolyGeo, lowPolyMat);
+    lowPolyTorus.castShadow = true;
+    lowPolyTorus.receiveShadow = true;
+    lowPolyTorus.position.x = 1.4;
+    toruses.push(lowPolyTorus);
+    scene.add(lowPolyTorus);
+
+    const hiPolyGeo = new THREE.TorusGeometry(1.1, 0.32, 64, 220);
+    const hiPolyMat = new THREE.MeshStandardMaterial({ color: 0x66ccff, metalness: 0.6, roughness: 0.1, envMapIntensity: 1.2 });
+    const hiPolyTorus = new THREE.Mesh(hiPolyGeo, hiPolyMat);
+    hiPolyTorus.castShadow = true;
+    hiPolyTorus.receiveShadow = true;
+    hiPolyTorus.position.set(0, 0.4, -1.2);
+    toruses.push(hiPolyTorus);
+    scene.add(hiPolyTorus);
 
     const pointLight = new THREE.PointLight(0xffffff, 2);
     pointLight.position.set(5, 5, 5);
@@ -149,8 +171,11 @@
 
     function animate() {
       requestAnimationFrame(animate);
-      torus.rotation.x += 0.005;
-      torus.rotation.y += 0.01;
+      toruses.forEach((mesh, idx) => {
+        const speed = 0.005 + idx * 0.003;
+        mesh.rotation.x += speed;
+        mesh.rotation.y += speed * 2;
+      });
       renderer.render(scene, camera);
     }
 


### PR DESCRIPTION
## Summary
- add support for multiple toruses and position the original neon shape
- introduce flat-shaded low-poly and glossy high-poly torus variations
- animate all toruses together for varied motion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692432eebe10832a9380685eb9800286)